### PR TITLE
wip

### DIFF
--- a/src/BasicArray.js
+++ b/src/BasicArray.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { RuntimeError } from './evaluate';
+import { RuntimeError } from './error';
 import { Value, ValueType } from './expr';
 
 export default class BasicArray {
@@ -30,7 +30,7 @@ export default class BasicArray {
   }
 
   /**
-   * @param {number} path
+   * @param {number[]} path
    * @param {Value} value
    */
   set(path, value) {

--- a/src/BasicFunction.js
+++ b/src/BasicFunction.js
@@ -1,8 +1,8 @@
 import moment from 'moment';
-import { RuntimeError } from './evaluate';
+import { RuntimeError } from './error';
 import { Value, ValueType } from './expr';
 
-class Function {
+export class BasicFunction {
   /**
    * @param {number} argCount - number of required arguments
    * @param {number} optArgCount - number of extra, optional arguments
@@ -14,7 +14,7 @@ class Function {
     this.fun = fun;
   }
 
-  call(args, context) {
+  call(args, program, context) {
     if (this.optArgCount) {
       if (
         args.length < this.argCount ||
@@ -123,12 +123,12 @@ const leftDollar = args => {
 
 export const builtinFunctions = () => {
   return {
-    sin: new Function(1, 0, ([angle]) => {
+    sin: new BasicFunction(1, 0, ([angle]) => {
       return new Value(ValueType.INT, Math.sin(angle.value));
     }),
-    ['TIME$']: new Function(0, 1, timeDollar),
-    ['DATE$']: new Function(0, 1, dateDollar),
-    ['LEN']: new Function(1, 0, len),
-    ['LEFT$']: new Function(2, 0, leftDollar),
+    ['TIME$']: new BasicFunction(0, 1, timeDollar),
+    ['DATE$']: new BasicFunction(0, 1, dateDollar),
+    ['LEN']: new BasicFunction(1, 0, len),
+    ['LEFT$']: new BasicFunction(2, 0, leftDollar),
   };
 };

--- a/src/UserFunction.js
+++ b/src/UserFunction.js
@@ -1,9 +1,39 @@
-class UserFunction {
+import { evaluate } from './eval';
+
+export class UserFunction {
   constructor(lineNumber) {
     this.lineNumber = lineNumber;
   }
 
-  call(args, context) {
+  async call(args, program, context) {
     context.push(context.pc);
+    context.scope();
+
+    const defLineIndex = program.lineNumberToIndex(this.lineNumber);
+    const defLine = program.lines[defLineIndex];
+
+    if (defLine.statements.length !== 1) {
+      throw new RuntimeError(
+        `DEF FN is not single statement on line ${this.lineNumber}`,
+        context,
+        program
+      );
+    }
+
+    const defStatement = defLine.statements[0];
+    const name = defStatement.name.toUpperCase();
+
+    let n = 0;
+    for (const arg of defStatement.args) {
+      context.assignVariable(arg.name, args[n]);
+      n = n + 1;
+    }
+
+    context.pc = program.lineNumberToIndex(this.lineNumber) + 1;
+    await evaluate(program, context);
+    context.pc = context.pop();
+    const scope = context.descope();
+
+    return scope.variables[name];
   }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,13 +1,7 @@
 import yargs from 'yargs';
 import readline from 'readline';
-import chalk from 'chalk';
 import fs from 'fs';
 
-// import { SyntaxError } from './parser';
-import { Program } from './program';
-import { Context } from './context';
-import { Value, ValueType } from './expr';
-import { builtinFunctions } from './function';
 import io from './io';
 import { setupEnvironment } from './utils';
 import { Stream } from './stream';
@@ -17,7 +11,7 @@ export const userInput = async prompt => {
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,
-    prompt: prompt
+    prompt: prompt,
   });
 
   return new Promise((resolve, reject) => {
@@ -27,8 +21,6 @@ export const userInput = async prompt => {
     });
   });
 };
-
-function setupStreams(context) {}
 
 function start(argv) {
   let program;
@@ -74,7 +66,7 @@ yargs
     yargs => {
       yargs.positional('source', {
         describe: 'filename of basic source to run',
-        type: 'string'
+        type: 'string',
       });
     },
     start

--- a/src/debugger.js
+++ b/src/debugger.js
@@ -7,8 +7,7 @@
 
 import { Program } from './program';
 import { Context } from './context';
-import { RuntimeError } from './evaluate';
-import io, { printError } from './io';
+import io from './io';
 import { input } from './shell';
 import { Line } from './line';
 import { evaluate } from './eval';

--- a/src/error.js
+++ b/src/error.js
@@ -1,0 +1,31 @@
+export class RuntimeError extends Error {
+  constructor(message, context, program, ...params) {
+    super(...params);
+    this.message = message;
+    this.setContext(context, program);
+  }
+
+  setContext(context, program) {
+    this.context = context;
+    if (context && program) {
+      this.line = program.lines[context.pc];
+    }
+    this.program = program;
+  }
+}
+
+export class InternalError extends Error {
+  constructor(message, context, program, ...params) {
+    super(...params);
+    this.message = message;
+    this.setContext(context, program);
+  }
+
+  setContext(context, program) {
+    this.context = context;
+    if (context && program) {
+      this.line = program.lines[context.pc];
+    }
+    this.program = program;
+  }
+}

--- a/src/eval.js
+++ b/src/eval.js
@@ -1,4 +1,4 @@
-import { RuntimeError } from './evaluate';
+import { RuntimeError } from './error';
 
 /**
  * @param {Program} program

--- a/src/evaluate.js
+++ b/src/evaluate.js
@@ -2,22 +2,6 @@ import { StatementType } from './statement';
 import { Keyword } from './lex';
 import { evaluate } from './eval';
 
-export class RuntimeError extends Error {
-  constructor(message, context, program, ...params) {
-    super(...params);
-    this.message = message;
-    this.setContext(context, program);
-  }
-
-  setContext(context, program) {
-    this.context = context;
-    if (context && program) {
-      this.line = program.lines[context.pc];
-    }
-    this.program = program;
-  }
-}
-
 const termPrintln = (value, context) => {
   context.stdout.write(value.toString());
   context.stdout.write('\n');

--- a/src/program.js
+++ b/src/program.js
@@ -1,6 +1,7 @@
 import { DefStatement } from './statements/DefStatement';
 import { Line } from './line';
 import { Value, ValueType } from './expr';
+import { UserFunction } from './UserFunction';
 
 export class Program {
   constructor(lines) {
@@ -44,7 +45,7 @@ export class Program {
     for (const line of this.lines) {
       for (const stmt of line.statements) {
         if (stmt instanceof DefStatement) {
-          functions[stmt.name] = line.num;
+          functions[stmt.name] = new UserFunction(line.num);
         }
       }
     }
@@ -99,10 +100,7 @@ export class Program {
 
     const userFunctions = this.getUserFunctions();
     for (const name of Object.keys(userFunctions)) {
-      context.assignConst(
-        name,
-        new Value(ValueType.USER_FUNCTION, userFunctions[name])
-      );
+      context.assignUserFunction(name, userFunctions[name]);
     }
   }
 }

--- a/src/shell.js
+++ b/src/shell.js
@@ -1,5 +1,5 @@
 import { Line } from './line';
-import { RuntimeError } from './evaluate';
+import { RuntimeError } from './error';
 
 const PROMPT = '] ';
 

--- a/src/statements/ChangeStatement.js
+++ b/src/statements/ChangeStatement.js
@@ -62,9 +62,6 @@ export class ChangeStatement extends BaseStatement {
       return;
     }
 
-    console.log(this.fromExpr);
-    console.log('fromArray', fromArray);
-    console.log('fromString', fromString);
     throw new RuntimeError('Invalid source expression in CHANGE statement');
   }
 }

--- a/src/statements/ChangeStatement.js
+++ b/src/statements/ChangeStatement.js
@@ -1,8 +1,14 @@
 import { BaseStatement, StatementType } from '../statement';
-import { Value, ValueType } from '../expr';
-import { RuntimeError } from '../evaluate';
+import { Value, ValueType, ExprType } from '../expr';
+import { RuntimeError } from '../error';
 
 export class ChangeStatement extends BaseStatement {
+  /**
+   * The from-expression must be either a variable name,
+   * pointing to an array or a string, or a string value.
+   * @param {Expr} fromExpr
+   * @param {*} toName
+   */
   constructor(fromExpr, toName) {
     super(StatementType.CHANGE);
     this.fromExpr = fromExpr;
@@ -10,10 +16,21 @@ export class ChangeStatement extends BaseStatement {
   }
 
   exec(program, context) {
-    const fromValue = this.fromExpr.evaluate(program, context);
+    let fromArray;
+    let fromString;
 
-    if (fromValue.type === ValueType.STRING) {
-      const str = fromValue.value;
+    if (this.fromExpr.type === ExprType.IDENT) {
+      const name = this.fromExpr.value;
+      fromArray = context.getArray(name);
+      if (!fromArray) {
+        fromString = context.get(name);
+      }
+    } else if (this.fromExpr.type === ExprType.CONST) {
+      fromString = this.fromExpr.value;
+    }
+
+    if (fromString && fromString.type === ValueType.STRING) {
+      const str = fromString.value;
       context.setArrayItem(
         this.toName,
         [0],
@@ -26,24 +43,28 @@ export class ChangeStatement extends BaseStatement {
           new Value(ValueType.INT, str.charCodeAt(i))
         );
       }
-    } else if (fromValue.type === ValueType.ARRAY) {
+      return;
+    }
+
+    if (fromArray) {
       // fromValue is an int array, where the first value is the
       // number of characters, and the remaining is characters in
       // ascii code. This array should be converted to a string.
-      const basicArray = fromValue.value;
-      const count = basicArray.get([0]).value;
+      const count = fromArray.get([0]).value;
       let str = '';
 
       for (let i = 0; i < count; i++) {
-        const n = basicArray.get([i + 1]);
+        const n = fromArray.get([i + 1]);
         str = str + String.fromCharCode(n.value);
       }
 
       context.assignVariable(this.toName, new Value(ValueType.STRING, str));
-    } else {
-      throw new RuntimeError(
-        `Invalid type in CHANGE statement: ${fromValue.type}`
-      );
+      return;
     }
+
+    console.log(this.fromExpr);
+    console.log('fromArray', fromArray);
+    console.log('fromString', fromString);
+    throw new RuntimeError('Invalid source expression in CHANGE statement');
   }
 }

--- a/src/statements/DimStatement.js
+++ b/src/statements/DimStatement.js
@@ -1,8 +1,8 @@
 import { BaseStatement, StatementType } from '../statement';
 import BasicArray from '../BasicArray';
-import { Value, ValueType } from '../expr';
-import io from '../io';
-import { RuntimeError } from '../evaluate';
+import { ValueType } from '../expr';
+import { Context } from '../context';
+import { Program } from '../program';
 
 export class DimStatement extends BaseStatement {
   constructor(arrays) {
@@ -10,6 +10,10 @@ export class DimStatement extends BaseStatement {
     this.arrays = arrays;
   }
 
+  /**
+   * @param {Program} program
+   * @param {Context} context
+   */
   exec(program, context) {
     for (const name of Object.keys(this.arrays)) {
       console.warn('DimStatement always use type "number"');
@@ -23,10 +27,7 @@ export class DimStatement extends BaseStatement {
         dataType = ValueType.INT;
       }
 
-      context.assignVariable(
-        name,
-        new Value(ValueType.ARRAY, new BasicArray(dataType, this.arrays[name]))
-      );
+      context.assignArray(name, new BasicArray(dataType, this.arrays[name]));
     }
   }
 }

--- a/src/statements/EndStatement.js
+++ b/src/statements/EndStatement.js
@@ -1,6 +1,6 @@
 import { BaseStatement, StatementType } from '../statement';
 import { Keyword } from '../lex';
-import { RuntimeError } from '../evaluate';
+import { RuntimeError } from '../error';
 
 export class EndStatement extends BaseStatement {
   constructor(blockType) {

--- a/src/statements/LetStatement.test.js
+++ b/src/statements/LetStatement.test.js
@@ -22,12 +22,9 @@ describe('LetStatement', () => {
 
   it('assigns value to array index', async () => {
     const context = new Context();
-    context.assignVariable(
+    context.assignArray(
       'v',
-      new Value(
-        ValueType.ARRAY,
-        new BasicArray(ValueType.STRING, [[0, 3], [0, 3]])
-      )
+      new BasicArray(ValueType.STRING, [[0, 3], [0, 3]])
     );
 
     const stmt = new LetStatement(
@@ -39,7 +36,7 @@ describe('LetStatement', () => {
     );
 
     await stmt.exec(undefined, context);
-    const v = context.scopes[0].variables.V.value;
+    const v = context.scopes[0].arrays.V;
 
     expect(v.get([1, 2])).to.deep.equal({
       type: ValueType.STRING,

--- a/src/statements/utils.js
+++ b/src/statements/utils.js
@@ -1,4 +1,4 @@
-import { RuntimeError } from '../evaluate';
+import { RuntimeError } from '../error';
 import { Value, ValueType } from '../expr';
 import Var from '../Var';
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,6 @@
 import { Program } from './program';
 import { Context } from './context';
-import { builtinFunctions } from './function';
-import { Value, ValueType } from './expr';
+import { builtinFunctions } from './BasicFunction';
 
 export const setupEnvironment = source => {
   const program = new Program();
@@ -9,7 +8,7 @@ export const setupEnvironment = source => {
   const builtins = builtinFunctions();
 
   for (let name of Object.keys(builtins)) {
-    context.assignConst(name, new Value(ValueType.FUNCTION, builtins[name]));
+    context.assignFunction(name, builtins[name]);
   }
 
   if (source) {

--- a/tests/dim1.bas
+++ b/tests/dim1.bas
@@ -1,0 +1,10 @@
+10 'Subscripted and unsubscripted can reuse the same variable name
+20 DIM X(20)
+30 X(1) = 123
+40 X = 456
+50 X(2) = 789
+60 PRINT X(1),X,X(2)
+----------
+123
+456
+789

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -1,12 +1,7 @@
 import fs from 'fs';
 
-import { Context } from '../src/context';
-import { Program } from '../src/program';
 import { Stream } from '../src/stream';
-import { Line } from '../src/line';
 import { evaluateStatement } from '../src/evaluate';
-import { Value, ValueType } from '../src/expr';
-import { builtinFunctions } from '../src/function';
 import { RunStatement } from '../src/statement';
 import { setupEnvironment } from '../src/utils';
 
@@ -23,7 +18,7 @@ describe('Integration tests', () => {
     const txtLines = [];
     let dst = basLines;
 
-    const skip = lines[0] && lines[0].trim() === '--- skip ---'
+    const skip = lines[0] && lines[0].trim() === '--- skip ---';
 
     for (let line of lines) {
       if (line.slice(0, 3) === '---') {
@@ -36,7 +31,7 @@ describe('Integration tests', () => {
     const src = basLines.join('\n');
     const txt = txtLines.join('\n').trim();
 
-    it(`${test}`, async function () {
+    it(`${test}`, async function() {
       if (skip) {
         this.skip();
         return;


### PR DESCRIPTION
In at least this specific BASIC dialect arrays, functions and other variables do not share
namespace. This means that `X` and `X(2)` points to two completely different objects.

Context has been refactored to have `arrays`, `functions` and `userFunctions`, besides
`constants` and `variables` that was already present. And arrays and functions have been
removed from the `ValueType` enum.

Also:

- Fixes a number of import problems
- Start a move of error types to `src/error.js`. Adds `InternalError`.
- `Function` is a JavaScript keyword. The `Function` class has been renamed to `BasicFunction`
- `UserFunction` share the same interface as `BasicFunction`, most importantly the `call` method
- More extensive JSDoc notations
