### PR TITLE
Add support for READ and DATA statements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
     "javascript.preferences.quoteStyle": "single",
     "prettier.singleQuote": true,
     "editor.formatOnSave": true,
-    "editor.tabSize": 2
+    "editor.tabSize": 2,
+    "javascript.implicitProjectConfig.checkJs": true
 }

--- a/src/Var.js
+++ b/src/Var.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-// Var is used to reference a variable in assignment
+// Var is used to reference a variable in assignment, READ
 // and INPUT statements. A Var is either a variable
 // name, or a name plus index into a single or multi-
 // dimensional array:
@@ -11,8 +11,9 @@
 //
 // Note that the Var class is *not* used in expressions
 // as there's no way to differentiate between a function
-// call and an index in an array:
+// call and an index in an array.
 import { Expr } from './expr';
+import { InternalError } from './error';
 
 export default class Var {
   /**

--- a/src/context.js
+++ b/src/context.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { Value, ValueType } from './expr';
-import { RuntimeError } from './error';
+import { RuntimeError, OutOfDataError } from './error';
 import BasicArray from './BasicArray';
 import { BasicFunction } from './BasicFunction';
 import { UserFunction } from './UserFunction';
@@ -35,6 +35,12 @@ export class Context {
     this.inputStream = undefined;
     this.outputStream = undefined;
 
+    /** @type {Value[]} */
+    this.data = [];
+
+    /** @type {number} */
+    this.dataIndex = 0;
+
     this.options = {
       verbose: false,
     };
@@ -44,6 +50,14 @@ export class Context {
 
     // @ts-ignore
     this.stdout = process.stdout;
+  }
+
+  getData() {
+    if (this.dataIndex >= this.data.length) {
+      throw new OutOfDataError();
+    }
+
+    return this.data[this.dataIndex++];
   }
 
   pushForLoop(data) {

--- a/src/error.js
+++ b/src/error.js
@@ -29,3 +29,10 @@ export class InternalError extends Error {
     this.program = program;
   }
 }
+
+export class OutOfDataError extends RuntimeError {
+  constructor(context, program) {
+    super('Out Of Data Error');
+    this.setContext(context, program);
+  }
+}

--- a/src/expr.js
+++ b/src/expr.js
@@ -47,6 +47,7 @@ export const ExprType = {
 export const ValueType = {
   INT: 'int',
   STRING: 'string',
+  FLOAT: 'float',
 };
 
 export class Value {

--- a/src/parser/parseDataStatement.js
+++ b/src/parser/parseDataStatement.js
@@ -1,15 +1,30 @@
 import { popKeyword, popOptionalType } from './utils';
 import { Keyword, TokenType } from '../lex';
 import { DataStatement } from '../statements/DataStatement';
+import { valueFromToken } from './utils';
+import { Value } from '../expr';
+import { Token } from '../lex';
 
+/**
+ * @param {Token[]} tokens
+ */
 export const parseDataStatement = tokens => {
   popKeyword(tokens, Keyword.DATA);
   const list = [];
 
   while (true) {
-    //console.log('FIXME!');
     // Should pop literals from tokens...
-    popOptionalType(tokens, [TokenType.INT, TokenType.STRING]);
+    const tok = popOptionalType(tokens, [
+      TokenType.INT,
+      TokenType.FLOAT,
+      TokenType.STRING,
+    ]);
+
+    if (!tok) {
+      break;
+    }
+
+    list.push(valueFromToken(tok));
 
     if (!popOptionalType(tokens, TokenType.COMMA)) {
       break;

--- a/src/parser/parseReadStatement.js
+++ b/src/parser/parseReadStatement.js
@@ -1,18 +1,21 @@
 import { parseVar } from './parseVar';
 import { popKeyword, popOptionalType } from './utils';
-import { Keyword, TokenType } from '../lex';
+import { Keyword, TokenType, Token } from '../lex';
 import { ReadStatement } from '../statements/ReadStatement';
 
+/**
+ * @param {Token[]} tokens
+ */
 export const parseReadStatement = tokens => {
   popKeyword(tokens, Keyword.READ);
-  const varList = [];
+  const list = [];
 
   while (true) {
-    varList.push(parseVar(tokens));
+    list.push(parseVar(tokens));
     if (!popOptionalType(tokens, TokenType.COMMA)) {
       break;
     }
   }
 
-  return new ReadStatement(varList);
+  return new ReadStatement(list);
 };

--- a/src/parser/utils.js
+++ b/src/parser/utils.js
@@ -1,4 +1,5 @@
-import { TokenType } from '../lex';
+import { Token, TokenType } from '../lex';
+import { Value, ValueType } from '../expr';
 
 export const expectLineLength = (tokens, length) => {
   if (tokens.length > length) {
@@ -113,4 +114,21 @@ export const popIdentifier = tokens => {
     throw new SyntaxError(`Expected identifier token, found ${tok.type}`);
   }
   return tok.value;
+};
+
+/**
+ * @param {Token} tok
+ * @returns {Value}
+ */
+export const valueFromToken = tok => {
+  switch (tok.type) {
+    case TokenType.FLOAT:
+      return new Value(ValueType.FLOAT, tok.value);
+    case TokenType.INT:
+      return new Value(ValueType.INT, tok.value);
+    case TokenType.STRING:
+      return new Value(ValueType.STRING, tok.value);
+    default:
+      throw new SyntaxError('Invalid value');
+  }
 };

--- a/src/program.js
+++ b/src/program.js
@@ -2,6 +2,7 @@ import { DefStatement } from './statements/DefStatement';
 import { Line } from './line';
 import { Value, ValueType } from './expr';
 import { UserFunction } from './UserFunction';
+import { DataStatement } from './statements/DataStatement';
 
 export class Program {
   constructor(lines) {
@@ -89,6 +90,33 @@ export class Program {
     return this.lines[idx];
   }
 
+  /**
+   * @param {Context} context
+   */
+  prepare(context) {
+    const userFunctions = this.getUserFunctions();
+    for (const name of Object.keys(userFunctions)) {
+      context.assignUserFunction(name, userFunctions[name]);
+    }
+
+    // Build data blocks
+    const data = [];
+    for (const line of this.lines) {
+      for (const stmt of line.statements) {
+        if (stmt instanceof DataStatement) {
+          data.push(...stmt.list);
+        }
+      }
+    }
+
+    context.data = data;
+    context.dataIndex = 0;
+  }
+
+  /**
+   * @param {string} source
+   * @param {Context} context
+   */
   loadFromString(source, context) {
     const lines = source.split('\n');
 
@@ -98,9 +126,6 @@ export class Program {
       }
     }
 
-    const userFunctions = this.getUserFunctions();
-    for (const name of Object.keys(userFunctions)) {
-      context.assignUserFunction(name, userFunctions[name]);
-    }
+    this.prepare(context);
   }
 }

--- a/src/statements/DataStatement.js
+++ b/src/statements/DataStatement.js
@@ -1,12 +1,18 @@
 import { BaseStatement, StatementType } from '../statement';
+import { Value } from '../expr';
 
 export class DataStatement extends BaseStatement {
+  /**
+   * @param {Value[]} list
+   */
   constructor(list) {
     super(StatementType.DATA);
+
+    /** @type {Value[]} */
     this.list = list;
   }
 
   exec(program, context) {
-    throw new Error('DATA is not implemented');
+    // Does nothing at runtime
   }
 }

--- a/src/statements/ReadStatement.js
+++ b/src/statements/ReadStatement.js
@@ -1,12 +1,28 @@
 import { BaseStatement, StatementType } from '../statement';
+import Var from '../Var';
+import { Program } from '../program';
+import { Context } from '../context';
+import { assignIdentifierValue } from './utils';
 
 export class ReadStatement extends BaseStatement {
+  /**
+   * @param {Var[]} list
+   */
   constructor(list) {
     super(StatementType.READ);
+
+    /** @type {Var[]} list */
     this.list = list;
   }
 
-  exec(program, context) {
-    throw new Error('Read is not implemented');
+  /**
+   * @param {Program} program
+   * @param {Context} context
+   */
+  async exec(program, context) {
+    for (const variable of this.list) {
+      const value = context.getData();
+      await assignIdentifierValue(program, context, variable, value);
+    }
   }
 }

--- a/src/statements/utils.js
+++ b/src/statements/utils.js
@@ -14,6 +14,7 @@ export const assignIdentifierValue = async (
 ) => {
   if (identifier.index) {
     const index = [];
+
     for (const expr of identifier.index) {
       index.push(await expr.evaluate(program, context));
     }

--- a/tests/for2.bas
+++ b/tests/for2.bas
@@ -6,4 +6,3 @@ Iteration 0
 Iteration 1
 Iteration 2
 Iteration 3
- 

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -20,8 +20,16 @@ describe('Integration tests', () => {
 
     const skip = lines[0] && lines[0].trim() === '--- skip ---';
 
+    let expectError;
+    let receivedError;
+
     for (let line of lines) {
-      if (line.slice(0, 3) === '---') {
+      // Example: --- throws: "Out Of Memory" ---
+      const throwMatch = line.match(/---+\s*throws:\s*"(.*)"/);
+
+      if (throwMatch) {
+        expectError = throwMatch[1];
+      } else if (line.slice(0, 3) === '---') {
         dst = txtLines;
       } else {
         dst.push(line);
@@ -46,7 +54,20 @@ describe('Integration tests', () => {
         output = output + data;
       });
 
-      await evaluateStatement(new RunStatement(), program, context);
+      try {
+        await evaluateStatement(new RunStatement(), program, context);
+      } catch (e) {
+        if (expectError) {
+          receivedError = e;
+        } else {
+          throw e;
+        }
+      }
+
+      if (expectError) {
+        expect(expectError).to.equal(receivedError.message);
+      }
+
       expect(output.trim()).to.equal(txt);
     });
   }

--- a/tests/read_and_data.bas
+++ b/tests/read_and_data.bas
@@ -1,0 +1,13 @@
+10 'Simple test of READ and DATA
+20 DATA 1,2,3
+30 READ X
+40 DATA 7,8,9
+50 READ A,B,C,D,E
+60 PRINT X,A,B,C,D,E
+--------
+1
+2
+3
+7
+8
+9

--- a/tests/read_and_data2.bas
+++ b/tests/read_and_data2.bas
@@ -1,0 +1,10 @@
+10 'Test of different data types in READ/DATA statements
+20 DATA 1, 3.14, "Hej"
+30 READ A, B, C
+40 PRINT A
+50 PRINT B
+60 PRINT C
+------
+1
+3.14
+Hej

--- a/tests/read_and_data_abuse.bas
+++ b/tests/read_and_data_abuse.bas
@@ -1,0 +1,3 @@
+10 DATA 1, 2, 3
+20 READ A, B, C, D
+--- throws: "Out Of Data Error" ---


### PR DESCRIPTION
This commit adds support for DATA and READ statements, which were only implemented as stubs.
When starting program execution, the context is initialized with data from all DATA statements
and the data index pointer is set to zero. For each data point read, using `Context.getData()`,
the index pointer is increased. If no data is available `OutOfDataError` is thrown.

Also:

- Enforce type checking VS Code using JSDoc
- Integration tests can expect errors using this syntax: `--- throws: "error message" ---`
- Adds basic support for float values
- Helper function `valueFromToken` added to `parser/utils`