### PR TITLE
Setup linter task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,13 +5,6 @@ jobs:
       - image: circleci/node:12.9.1
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "package.json" }}
-            - v1-dependencies-
       - run: npm install
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
-      - run: npm test
+      - run: npm run lint
+      - run: npm run test

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,52 @@
+{
+  "env": {
+    // "browser": true,
+    // "es6": true,
+    // "node": true,
+    "mocha": true
+  },
+  "extends": ["airbnb-base", "plugin:jsdoc/recommended", "prettier"],
+  "globals": {
+    "Atomics": "readonly",
+    "SharedArrayBuffer": "readonly"
+  },
+  "parserOptions": {
+    "ecmaVersion": 2018,
+    "sourceType": "module"
+  },
+  "rules": {
+    "import/prefer-default-export": 0,
+    "max-classes-per-file": 0,
+    "jsdoc/require-param-description": 0,
+    "jsdoc/require-returns-description": 0,
+    "no-unused-vars": ["error", { "args": "after-used" }],
+
+    // Allow for-of loops as they are efficient and readable.
+    "no-restricted-syntax": 0,
+
+    // for-loops that await on async operations are the
+    // most readable way to run async operations in series.
+    "no-await-in-loop": 0,
+
+    // Some classes that extend and overrides methods in a base class
+    // do not need to reference "this".
+    "class-methods-use-this": 0,
+
+    // We may way to enable this at a later stage, but currently
+    // we rely too much on console output, not streams.
+    "no-console": 0,
+
+    // Personal preference
+    "no-plusplus": 0,
+
+    // In most cases it's fine to leave out return statement if a
+    // function is supposed to return undefined in some situations
+    "consistent-return": 0,
+
+    // Chai and Yargs, among others, breaks this rule. With Chai
+    // it wrongly detects `expect(foo).to.be.true` to be an unused
+    // expression as it does not end with a function call.
+    "no-unused-expressions": 0
+  },
+  "plugins": ["jsdoc"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,5 @@
     "javascript.preferences.quoteStyle": "single",
     "prettier.singleQuote": true,
     "editor.formatOnSave": true,
-    "editor.tabSize": 2,
-    "javascript.implicitProjectConfig.checkJs": true
+    "editor.tabSize": 2
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -122,10 +122,40 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "acorn": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
+      "integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
     "ansi-colors": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
       "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "dev": true
+    },
+    "ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
       "dev": true
     },
     "ansi-regex": {
@@ -166,10 +196,26 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "array-includes": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
+      }
+    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
     "balanced-match": {
@@ -205,6 +251,12 @@
         "package-hash": "^3.0.0",
         "write-file-atomic": "^2.4.2"
       }
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
     },
     "camelcase": {
       "version": "5.3.1",
@@ -245,10 +297,31 @@
         }
       }
     },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
     "cliui": {
@@ -282,11 +355,17 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.1.tgz",
+      "integrity": "sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg==",
       "dev": true,
       "optional": true
+    },
+    "comment-parser": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.6.2.tgz",
+      "integrity": "sha512-Wdms0Q8d4vvb2Yk72OwZjwNWtMklbC5Re7lD9cjCP/AG1fhocmc0TrxGBBAXPLy8fZQPrfHGgyygwI0lA7pbzA==",
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -298,6 +377,18 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "confusing-browser-globals": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz",
+      "integrity": "sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==",
+      "dev": true
+    },
+    "contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
     "convert-source-map": {
@@ -357,6 +448,12 @@
         "type-detect": "^4.0.0"
       }
     },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
     "default-require-extensions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
@@ -380,6 +477,15 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
     },
     "emoji-regex": {
       "version": "7.0.3",
@@ -439,15 +545,461 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
+    "eslint": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.5.1.tgz",
+      "integrity": "sha512-32h99BoLYStT1iq1v2P9uwpyznQ4M2jRiFB6acitKz52Gqn+vPaMDUTB1bYi1WN4Nquj2w+t+bimYUG83DC55A==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.10.0",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^1.4.2",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.1.1",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^6.4.1",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.14",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^6.1.2",
+        "strip-ansi": "^5.2.0",
+        "strip-json-comments": "^3.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+          "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-config-airbnb-base": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.0.0.tgz",
+      "integrity": "sha512-2IDHobw97upExLmsebhtfoD3NAKhV4H0CJWP3Uprd/uk+cHuWYOczPVxQ8PxLFUAw7o3Th1RAU8u1DoUpr+cMA==",
+      "dev": true,
+      "requires": {
+        "confusing-browser-globals": "^1.0.7",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.1.0"
+      }
+    },
+    "eslint-config-prettier": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.3.0.tgz",
+      "integrity": "sha512-EWaGjlDAZRzVFveh2Jsglcere2KK5CJBhkNSa1xs3KfMUGdRiT7lG089eqPdvlzWHpAqaekubOsOMu8W8Yk71A==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
+      }
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+      "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "resolve": "^1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz",
+      "integrity": "sha512-H6DOj+ejw7Tesdgbfs4jeS4YMFrT8uI8xwd1gtQqXssaR0EQ26L+2O/w6wkYFy2MymON0fTwHmXBvvfLNZVZEw==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.8",
+        "pkg-dir": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.1.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
+      "integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.9",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "^0.3.2",
+        "eslint-module-utils": "^2.4.0",
+        "has": "^1.0.3",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.0",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.11.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-jsdoc": {
+      "version": "15.9.10",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-15.9.10.tgz",
+      "integrity": "sha512-m3jQQ7MJCnOksAhrQU5wSuPZQND1qvFNGBddhM2k3P9dJRg1N0fKHl79SE2ZV/ykd2RV1flsMHEa46kY2RCUPA==",
+      "dev": true,
+      "requires": {
+        "comment-parser": "^0.6.2",
+        "debug": "^4.1.1",
+        "jsdoctypeparser": "^5.1.1",
+        "lodash": "^4.17.15",
+        "object.entries-ponyfill": "^1.0.1",
+        "regextras": "^0.6.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+      "dev": true
+    },
     "esm": {
       "version": "3.2.25",
       "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
       "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
     },
+    "espree": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
+      "integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.0.0",
+        "acorn-jsx": "^5.0.2",
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
     "esutils": {
@@ -468,6 +1020,53 @@
         "p-finally": "^1.0.0",
         "signal-exit": "^3.0.0",
         "strip-eof": "^1.0.0"
+      }
+    },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
       }
     },
     "find-cache-dir": {
@@ -497,6 +1096,34 @@
       "requires": {
         "is-buffer": "~2.0.3"
       }
+    },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "flatted": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+      "dev": true
     },
     "foreground-child": {
       "version": "1.5.6",
@@ -532,6 +1159,12 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -541,6 +1174,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
     },
     "get-stream": {
@@ -565,6 +1204,15 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "glob-parent": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -584,9 +1232,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.0.tgz",
-      "integrity": "sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.2.tgz",
+      "integrity": "sha512-cIv17+GhL8pHHnRJzGu2wwcthL5sb8uDKBHvZ2Dtu5s1YNt0ljbzKbamnc+gr69y7bzwQiBdr5+hOpRd5pnOdg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -644,6 +1292,31 @@
       "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
       "dev": true
     },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
+      "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -665,6 +1338,44 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
+    },
+    "inquirer": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+      "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.12",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
     },
     "invert-kv": {
       "version": "2.0.0",
@@ -695,10 +1406,31 @@
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
     },
     "is-regex": {
       "version": "1.0.4",
@@ -722,6 +1454,12 @@
       "requires": {
         "has-symbols": "^1.0.0"
       }
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -843,6 +1581,12 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsdoctypeparser": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-5.1.1.tgz",
+      "integrity": "sha512-APGygIJrT5bbz5lsVt8vyLJC0miEbQf/z9ZBfTr4RYvdia8AhWMRlYgivvwHG5zKD/VW3d6qpChCy64hpQET3A==",
+      "dev": true
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -855,12 +1599,34 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
     "lcid": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
       "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
       "requires": {
         "invert-kv": "^2.0.0"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "load-json-file": {
@@ -1086,6 +1852,18 @@
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true
     },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
     "neo-async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
@@ -1190,6 +1968,24 @@
         "object-keys": "^1.0.11"
       }
     },
+    "object.entries": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
+    "object.entries-ponyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object.entries-ponyfill/-/object.entries-ponyfill-1.0.1.tgz",
+      "integrity": "sha1-Kavfd8v70mVm3RqiTp2I9lQz0lY=",
+      "dev": true
+    },
     "object.getownpropertydescriptors": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
@@ -1200,12 +1996,41 @@
         "es-abstract": "^1.5.1"
       }
     },
+    "object.values": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
+      "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      },
+      "dependencies": {
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+          "dev": true
+        }
       }
     },
     "optimist": {
@@ -1216,6 +2041,28 @@
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+          "dev": true
+        }
       }
     },
     "os-homedir": {
@@ -1233,6 +2080,12 @@
         "lcid": "^2.0.0",
         "mem": "^4.0.0"
       }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
     "p-defer": {
       "version": "1.0.0",
@@ -1280,6 +2133,15 @@
         "hasha": "^3.0.0",
         "lodash.flattendeep": "^4.4.0",
         "release-zalgo": "^1.0.0"
+      }
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
       }
     },
     "parse-json": {
@@ -1352,6 +2214,18 @@
         "find-up": "^3.0.0"
       }
     },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -1366,6 +2240,12 @@
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "read-pkg": {
       "version": "3.0.0",
@@ -1387,6 +2267,18 @@
         "find-up": "^3.0.0",
         "read-pkg": "^3.0.0"
       }
+    },
+    "regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
+    },
+    "regextras": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.6.1.tgz",
+      "integrity": "sha512-EzIHww9xV2Kpqx+corS/I7OBmf2rZ0pKKJPsw5Dc+l6Zq1TslDmtRIP9maVn3UH+72MIXmn8zzDgP07ihQogUA==",
+      "dev": true
     },
     "release-zalgo": {
       "version": "1.0.0",
@@ -1422,6 +2314,16 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
     },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "rimraf": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -1431,10 +2333,34 @@
         "glob": "^7.1.3"
       }
     },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rxjs": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
+      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
     "semver": {
@@ -1464,6 +2390,17 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      }
     },
     "source-map": {
       "version": "0.5.7",
@@ -1568,6 +2505,46 @@
         "has-flag": "^3.0.0"
       }
     },
+    "table": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
     "test-exclude": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
@@ -1578,6 +2555,27 @@
         "minimatch": "^3.0.4",
         "read-pkg-up": "^4.0.0",
         "require-main-filename": "^2.0.0"
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
       }
     },
     "to-fast-properties": {
@@ -1591,6 +2589,21 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
+    },
+    "tslib": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
     },
     "type-detect": {
       "version": "4.0.8",
@@ -1618,10 +2631,25 @@
         }
       }
     },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "uuid": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
       "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+      "dev": true
+    },
+    "v8-compile-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -1713,6 +2741,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     },
     "write-file-atomic": {
       "version": "2.4.3",

--- a/package.json
+++ b/package.json
@@ -6,13 +6,19 @@
   "types": "./types/index.d.ts",
   "scripts": {
     "start": "node --inspect -r esm src/cli.js",
-    "test": "mocha -r esm \"./**/*.test.js\"",
-    "coverage": "nyc --reporter=text mocha -r esm \"./**/*.test.js\""
+    "test": "mocha -r esm \"./src/**/*.test.js\" ./tests/*.test.js",
+    "lint": "eslint \"tests/**/*.js\" \"src/**/*.js\"",
+    "coverage": "nyc --reporter=text mocha -r esm \"./src/**/*.test.js\" ./tests/*.test.js"
   },
   "author": "Jonatan Magnusson",
   "license": "ISC",
   "devDependencies": {
     "chai": "^4.2.0",
+    "eslint": "^6.5.1",
+    "eslint-config-airbnb-base": "^14.0.0",
+    "eslint-config-prettier": "^6.3.0",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-jsdoc": "^15.9.10",
     "mocha": "^6.1.4",
     "nyc": "^14.1.1"
   },

--- a/src/BasicArray.js
+++ b/src/BasicArray.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { RuntimeError } from './error';
-import { Value, ValueType } from './expr';
+import { Value, ValueType } from './Value';
 
 export default class BasicArray {
   /**
@@ -23,7 +23,7 @@ export default class BasicArray {
 
     for (let i = 0; i < path.length - 1; i++) {
       const dim = this.dimensions[i];
-      index = index + (dim[1] - dim[0]) * path[i];
+      index += (dim[1] - dim[0]) * path[i];
     }
 
     return index + path[path.length - 1];

--- a/src/BasicArray.test.js
+++ b/src/BasicArray.test.js
@@ -1,7 +1,5 @@
-const chai = require('chai');
-const expect = chai.expect;
-
-import { Value, ValueType } from './expr';
+import { expect } from 'chai';
+import { Value, ValueType } from './Value';
 import BasicArray from './BasicArray';
 
 describe('BasicArray', () => {
@@ -28,10 +26,12 @@ describe('BasicArray', () => {
       const data = ['a', 'b', 'c', 'd'];
 
       for (let j = 0; j < 5; j++) {
+        // eslint-disable-next-line
         data.forEach((c, i) => a.set([j, i], new Value(ValueType.INT, c)));
       }
 
       for (let j = 0; j < 5; j++) {
+        // eslint-disable-next-line
         data.forEach((c, i) => {
           const item = a.get([j, i]);
           expect(item.value).to.equal(c);

--- a/src/BasicFunction.js
+++ b/src/BasicFunction.js
@@ -1,12 +1,12 @@
 import moment from 'moment';
 import { RuntimeError } from './error';
-import { Value, ValueType } from './expr';
+import { Value, ValueType } from './Value';
 
 export class BasicFunction {
   /**
    * @param {number} argCount - number of required arguments
    * @param {number} optArgCount - number of extra, optional arguments
-   * @param {function} fun - the JavaScript function
+   * @param {Function} fun - the JavaScript function
    */
   constructor(argCount, optArgCount, fun) {
     this.argCount = argCount;
@@ -25,12 +25,10 @@ export class BasicFunction {
             this.optArgCount} arguments, got ${args.length}`
         );
       }
-    } else {
-      if (args.length !== this.argCount) {
-        throw new RuntimeError(
-          `Expected ${this.argCount} arguments, got ${args.length}`
-        );
-      }
+    } else if (args.length !== this.argCount) {
+      throw new RuntimeError(
+        `Expected ${this.argCount} arguments, got ${args.length}`
+      );
     }
 
     return this.fun(args, context);
@@ -85,7 +83,7 @@ const timeDollar = args => {
 };
 
 const dateDollar = args => {
-  let dateArg = args[0];
+  const dateArg = args[0];
   let date;
 
   if (dateArg) {
@@ -116,9 +114,9 @@ const leftDollar = args => {
 
   if (n >= 0) {
     return new Value(ValueType.STRING, args[0].value.slice(0, n));
-  } else {
-    return new Value(ValueType.STRING, args[0].value);
   }
+
+  return new Value(ValueType.STRING, args[0].value);
 };
 
 export const builtinFunctions = () => {
@@ -126,9 +124,9 @@ export const builtinFunctions = () => {
     sin: new BasicFunction(1, 0, ([angle]) => {
       return new Value(ValueType.INT, Math.sin(angle.value));
     }),
-    ['TIME$']: new BasicFunction(0, 1, timeDollar),
-    ['DATE$']: new BasicFunction(0, 1, dateDollar),
-    ['LEN']: new BasicFunction(1, 0, len),
-    ['LEFT$']: new BasicFunction(2, 0, leftDollar),
+    TIME$: new BasicFunction(0, 1, timeDollar),
+    DATE$: new BasicFunction(0, 1, dateDollar),
+    LEN: new BasicFunction(1, 0, len),
+    LEFT$: new BasicFunction(2, 0, leftDollar),
   };
 };

--- a/src/UserFunction.js
+++ b/src/UserFunction.js
@@ -1,4 +1,5 @@
 import { evaluate } from './eval';
+import { RuntimeError } from './error';
 
 export class UserFunction {
   constructor(lineNumber) {
@@ -26,11 +27,14 @@ export class UserFunction {
     let n = 0;
     for (const arg of defStatement.args) {
       context.assignVariable(arg.name, args[n]);
-      n = n + 1;
+      n += 1;
     }
 
+    // eslint-disable-next-line no-param-reassign
     context.pc = program.lineNumberToIndex(this.lineNumber) + 1;
     await evaluate(program, context);
+
+    // eslint-disable-next-line no-param-reassign
     context.pc = context.pop();
     const scope = context.descope();
 

--- a/src/Value.js
+++ b/src/Value.js
@@ -1,0 +1,46 @@
+import { InternalError } from './error';
+
+/**
+ * @enum {string}
+ */
+export const ValueType = {
+  INT: 'int',
+  STRING: 'string',
+  FLOAT: 'float',
+};
+
+export class Value {
+  /**
+   * @param {ValueType} type
+   * @param {*} value
+   */
+  constructor(type, value) {
+    this.type = type;
+    this.value = value;
+  }
+
+  /**
+   * @returns {boolean}
+   */
+  isNumeric() {
+    return this.type === ValueType.INT;
+  }
+
+  isLessThan(other) {
+    // FIXME: be more correct!
+    return this.value < other.value;
+  }
+
+  add(value) {
+    return new Value(this.type, this.value + value.value);
+  }
+
+  isTrue() {
+    switch (this.type) {
+      case ValueType.INT:
+        return this.value !== 0;
+      default:
+        throw new InternalError(`isTrue not implemented for type ${this.type}`);
+    }
+  }
+}

--- a/src/Var.js
+++ b/src/Var.js
@@ -13,7 +13,6 @@
 // as there's no way to differentiate between a function
 // call and an index in an array.
 import { Expr } from './expr';
-import { InternalError } from './error';
 
 export default class Var {
   /**

--- a/src/cli.js
+++ b/src/cli.js
@@ -9,9 +9,9 @@ import { shell } from './shell';
 
 export const userInput = async prompt => {
   const rl = readline.createInterface({
+    prompt,
     input: process.stdin,
     output: process.stdout,
-    prompt: prompt,
   });
 
   return new Promise((resolve, reject) => {
@@ -22,13 +22,14 @@ export const userInput = async prompt => {
   });
 };
 
-function start(argv) {
+const start = argv => {
   let program;
   let context;
   let source = '';
 
-  for (let filename of argv['_']) {
-    source += fs.readFileSync(filename, 'utf-8') + '\n';
+  for (const filename of argv._) {
+    source += fs.readFileSync(filename, 'utf-8');
+    source += '\n';
   }
 
   try {
@@ -51,20 +52,21 @@ function start(argv) {
 
   context.outputStream = new Stream();
   context.outputStream.on('data', () => {
-    const data = context.outputStream.read();
+    context.outputStream.read();
   });
 
   context.outputStream.on('data', data => process.stdout.write(data));
 
   shell(program, context);
-}
+};
 
+// eslint-disable-next-line no-unused-expressions
 yargs
   .command(
     '*',
     'start bajsic interpreter',
-    yargs => {
-      yargs.positional('source', {
+    args => {
+      args.positional('source', {
         describe: 'filename of basic source to run',
         type: 'string',
       });

--- a/src/debugger.js
+++ b/src/debugger.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 // @ts-check
 
 // @ts-ignore
@@ -9,14 +10,13 @@ import { Program } from './program';
 import { Context } from './context';
 import io from './io';
 import { input } from './shell';
-import { Line } from './line';
 import { evaluate } from './eval';
 
 const PROMPT = 'dbg> ';
 
 export const userInput = async (context, prompt) => {
-  context.outputStream.write(PROMPT);
-  return await input(context.inputStream);
+  context.outputStream.write(prompt);
+  return input(context.inputStream);
 };
 
 class Debugger {
@@ -81,9 +81,8 @@ class Debugger {
   /**
    * @param {string[]} args
    * @param {Program} program
-   * @param {Context} context
    */
-  async cmdList(args, program, context) {
+  async cmdList(args, program) {
     for (const arg of args) {
       if (arg.startsWith('u')) {
         // List user functions
@@ -98,11 +97,6 @@ class Debugger {
       }
     }
   }
-
-  /**
-   * @param {Line} line
-   * @returns {boolean}
-   */
 
   /**
    * @param {Program} program
@@ -123,7 +117,7 @@ class Debugger {
       return false;
     };
 
-    while (true) {
+    for (;;) {
       const line = program.lines[context.pc];
       let evaluateNext = true;
 

--- a/src/debugger.js
+++ b/src/debugger.js
@@ -9,14 +9,13 @@
 import { Program } from './program';
 import { Context } from './context';
 import io from './io';
-import { input } from './shell';
 import { evaluate } from './eval';
 
 const PROMPT = 'dbg> ';
 
 export const userInput = async (context, prompt) => {
   context.outputStream.write(prompt);
-  return input(context.inputStream);
+  return io.input(context.inputStream);
 };
 
 class Debugger {

--- a/src/error.js
+++ b/src/error.js
@@ -1,3 +1,18 @@
+export class LexicalError extends Error {
+  constructor(message, column, ...params) {
+    super(...params);
+    this.message = message;
+    this.column = column;
+  }
+}
+
+export class SyntaxError extends Error {
+  constructor(message, ...params) {
+    super(...params);
+    this.message = message;
+  }
+}
+
 export class RuntimeError extends Error {
   constructor(message, context, program, ...params) {
     super(...params);
@@ -32,7 +47,12 @@ export class InternalError extends Error {
 
 export class OutOfDataError extends RuntimeError {
   constructor(context, program) {
-    super('Out Of Data Error');
-    this.setContext(context, program);
+    super('Out Of Data Error', context, program);
+  }
+}
+
+export class NextWithoutForError extends RuntimeError {
+  constructor(context, program) {
+    super('Next Without For Error', context, program);
   }
 }

--- a/src/eval.js
+++ b/src/eval.js
@@ -1,9 +1,12 @@
+/* eslint-disable no-param-reassign */
+
 import { RuntimeError } from './error';
+import { Program } from './program';
 
 /**
  * @param {Program} program
- * @param {Context} context
- * @param {number?} lines - number of lines to evaluate
+ * @param {any} context
+ * @param {boolean} single only evaluate one line
  */
 export const evaluate = async (program, context, single) => {
   let first = true;
@@ -20,7 +23,7 @@ export const evaluate = async (program, context, single) => {
     }
 
     if (nextLine === undefined) {
-      context.pc = context.pc + 1;
+      context.pc += 1;
       if (context.pc >= program.lines.length) {
         break;
       }

--- a/src/evaluate.js
+++ b/src/evaluate.js
@@ -1,11 +1,5 @@
 import { StatementType } from './statement';
-import { Keyword } from './lex';
 import { evaluate } from './eval';
-
-const termPrintln = (value, context) => {
-  context.stdout.write(value.toString());
-  context.stdout.write('\n');
-};
 
 const evalList = (statement, program, context) => {
   if (statement.ranges.length === 0) {
@@ -24,14 +18,14 @@ const evalPrint = async (statement, program, context) => {
   // FIXME: handle different output channels
   for (const outp of statement.list) {
     const result = await outp[0].evaluate(program, context);
-    outp[1]
-      ? context.outputStream.write(`${result.value}\n`)
-      : context.outputStream.write(`${result.value}`);
+    context.outputStream.write(
+      outp[1] ? `${result.value}\n` : `${result.value}`
+    );
   }
 };
 
 const evalRun = async (statement, program, context) => {
-  context.pc = 0;
+  context.prepare(program);
   await evaluate(program, context);
 };
 
@@ -43,11 +37,11 @@ const evalMap = {
 
 export const evaluateStatement = async (statement, program, context) => {
   if (statement.exec) {
-    return await statement.exec(program, context);
+    return statement.exec(program, context);
   }
 
   if (evalMap[statement.type]) {
-    return await evalMap[statement.type](statement, program, context);
+    return evalMap[statement.type](statement, program, context);
   }
 
   throw new Error(

--- a/src/io.js
+++ b/src/io.js
@@ -8,6 +8,12 @@ const printError = text => {
   console.error(chalk.redBright(text));
 };
 
+const input = async stream => {
+  return new Promise(resolve => {
+    stream.once('data', data => resolve(data));
+  });
+};
+
 /**
  * @param {Error} e
  */
@@ -28,4 +34,5 @@ export default {
   print,
   printError,
   printRuntimeError,
+  input,
 };

--- a/src/io.js
+++ b/src/io.js
@@ -1,13 +1,16 @@
 import chalk from 'chalk';
 
-export const print = text => {
+const print = text => {
   console.log(text === undefined ? '' : text);
 };
 
-export const printError = text => {
+const printError = text => {
   console.error(chalk.redBright(text));
 };
 
+/**
+ * @param {Error} e
+ */
 function printRuntimeError(e) {
   if (e.line) {
     let msg = `Runtime error on line ${e.line.num}: ${e.message}`;
@@ -24,5 +27,5 @@ function printRuntimeError(e) {
 export default {
   print,
   printError,
-  printRuntimeError
+  printRuntimeError,
 };

--- a/src/lex.js
+++ b/src/lex.js
@@ -1,3 +1,5 @@
+import { LexicalError } from './error';
+
 export const TokenType = {
   COLON: 'colon',
   COMMA: 'comma',
@@ -29,7 +31,6 @@ export const TokenType = {
   AND: 'and',
   OR: 'or',
   XOR: 'xor',
-  NOT: 'not',
 
   // FIXME: I'm not sure about the meaning of underscore
   //        It's often found in INPUT statements:
@@ -101,45 +102,37 @@ export class Token {
   }
 }
 
-export class LexicalError extends Error {
-  constructor(message, column, ...params) {
-    super(...params);
-    this.message = message;
-    this.column = column;
-  }
-}
-
-export const tokenize = (source, sourceLineNo) => {
+export const tokenize = source => {
   const space = ' \t';
   const numeric = '0123456789';
   const lowerAlpha = 'abcdefghijklmnopqrstuvwxyz';
   const alpha = lowerAlpha + lowerAlpha.toUpperCase();
   const alphaNumeric = alpha + numeric;
   const remarkChar = "'";
-  const nameCharacters = alphaNumeric + '$%';
+  const nameCharacters = `${alphaNumeric}$%`;
   const tokens = [];
   const twoCharacterToken = {
-    ['<>']: TokenType.NE,
-    ['<=']: TokenType.LE,
-    ['>=']: TokenType.GE,
-    ['==']: TokenType.APPROX_EQ,
+    '<>': TokenType.NE,
+    '<=': TokenType.LE,
+    '>=': TokenType.GE,
+    '==': TokenType.APPROX_EQ,
   };
   const singleCharacterToken = {
-    [',']: TokenType.COMMA,
-    ['(']: TokenType.LPAR,
-    [')']: TokenType.RPAR,
-    ['\\']: TokenType.SEPARATOR,
-    ['<']: TokenType.LT,
-    ['=']: TokenType.EQ,
-    ['>']: TokenType.GT,
-    ['+']: TokenType.PLUS,
-    ['-']: TokenType.MINUS,
-    ['*']: TokenType.MUL,
-    ['/']: TokenType.DIV,
-    [':']: TokenType.COLON,
-    [';']: TokenType.SEMICOLON,
-    ['_']: TokenType.UNDERSCORE,
-    ['#']: TokenType.HASH,
+    ',': TokenType.COMMA,
+    '(': TokenType.LPAR,
+    ')': TokenType.RPAR,
+    '\\': TokenType.SEPARATOR,
+    '<': TokenType.LT,
+    '=': TokenType.EQ,
+    '>': TokenType.GT,
+    '+': TokenType.PLUS,
+    '-': TokenType.MINUS,
+    '*': TokenType.MUL,
+    '/': TokenType.DIV,
+    ':': TokenType.COLON,
+    ';': TokenType.SEMICOLON,
+    _: TokenType.UNDERSCORE,
+    '#': TokenType.HASH,
   };
   let i = 0;
 
@@ -166,7 +159,7 @@ export const tokenize = (source, sourceLineNo) => {
       i++;
     }
 
-    const value = type === TokenType.INT ? parseInt(sub) : parseFloat(sub);
+    const value = type === TokenType.INT ? parseInt(sub, 10) : parseFloat(sub);
     return { type, value };
   };
 
@@ -201,6 +194,8 @@ export const tokenize = (source, sourceLineNo) => {
         return new Token(TokenType.NOT);
       case 'XOR':
         return new Token(TokenType.XOR);
+      default:
+        break;
     }
 
     if (Object.keys(keywordAliases).includes(word)) {
@@ -231,6 +226,7 @@ export const tokenize = (source, sourceLineNo) => {
   };
 
   while (i < source.length) {
+    /* eslint-disable no-continue */
     skipSpace();
 
     if (i < source.length) {

--- a/src/lex.test.js
+++ b/src/lex.test.js
@@ -1,7 +1,6 @@
-const chai = require('chai');
-const expect = chai.expect;
-
-import { tokenize, TokenType, Keyword, LexicalError } from './lex';
+import { expect } from 'chai';
+import { tokenize, TokenType, Keyword } from './lex';
+import { LexicalError } from './error';
 
 describe('Lexical Analyzer', () => {
   it('handles empty lines', () => {

--- a/src/line.js
+++ b/src/line.js
@@ -1,5 +1,3 @@
-import { TokenType, LexicalError, tokenize } from './lex';
-import { SyntaxError, parseStatements } from './parser';
 import { evaluateStatement } from './evaluate';
 
 export class Line {
@@ -8,40 +6,6 @@ export class Line {
     this.sourceLineNo = sourceLineNo;
     this.num = undefined;
     this.statements = [];
-  }
-
-  static parse(source, sourceLineNo) {
-    const line = new Line(source, sourceLineNo);
-
-    // Lexical analyze
-    let tokens;
-    try {
-      tokens = tokenize(source, sourceLineNo);
-    } catch (e) {
-      if (e instanceof LexicalError) {
-        e.code = source;
-        e.line = sourceLineNo;
-      }
-      throw e;
-    }
-
-    // Handle initial line number token
-    if (tokens.length > 0 && tokens[0].type === TokenType.INT) {
-      line.num = tokens[0].value;
-      tokens.shift();
-    }
-
-    try {
-      line.statements = parseStatements(tokens);
-    } catch (e) {
-      if (e instanceof SyntaxError) {
-        e.code = source;
-        e.lineNumber = sourceLineNo;
-      }
-      throw e;
-    }
-
-    return line;
   }
 
   async exec(program, context) {
@@ -56,5 +20,7 @@ export class Line {
         return next;
       }
     }
+
+    return undefined;
   }
 }

--- a/src/parser/expression.js
+++ b/src/parser/expression.js
@@ -7,7 +7,6 @@ import {
   ConstExpr,
   IdentifierExpr,
   MultiplyExpr,
-  ValueType,
   RelationalOperatorExpr,
   ExprType,
   SubtractExpr,
@@ -15,6 +14,8 @@ import {
   NotExpr,
   UnaryMinusExpr,
 } from '../expr';
+
+import { ValueType } from '../Value';
 
 const Operator = {
   EXP: 'EXP',
@@ -120,12 +121,12 @@ const prec = {
   [Operator.EQV]: 11,
 };
 
-function assert(cond, message, obj) {
+const assert = (cond, message, obj) => {
   if (!cond) {
     const msg = obj ? `${message} (${JSON.stringify(obj, null, 2)})` : message;
     throw new SyntaxError(msg);
   }
-}
+};
 
 const operands = [
   TokenType.INT,

--- a/src/parser/expression.test.js
+++ b/src/parser/expression.test.js
@@ -1,18 +1,18 @@
+import { expect } from 'chai';
+
 import { parseExpression } from './expression';
 import { Token, TokenType } from '../lex';
 import {
   ConstExpr,
-  ValueType,
   CallExpr,
   AddExpr,
   MultiplyExpr,
   ExprType,
   IdentifierExpr,
-  UnaryMinusExpr
+  UnaryMinusExpr,
 } from '../expr';
 
-const chai = require('chai');
-const expect = chai.expect;
+import { ValueType } from '../Value';
 
 const {
   INT,
@@ -23,10 +23,10 @@ const {
   STRING,
   COMMA,
   NOT,
-  MINUS
+  MINUS,
 } = TokenType;
 
-function printExprTree(expr, indent) {
+const printExprTree = (expr, indent) => {
   const indent2 = indent || '';
 
   if (expr === undefined) {
@@ -38,37 +38,36 @@ function printExprTree(expr, indent) {
     `${indent2}${expr.type} ${expr.value !== undefined ? expr.value : ''}`
   );
   if (expr.children) {
-    for (let child of expr.children || []) {
-      printExprTree(child, indent2 + '--');
+    for (const child of expr.children || []) {
+      printExprTree(child, `${indent2}--`);
     }
   }
-}
+};
 
-function compareExpressions(expr1, expr2) {
-  function printDiff() {
+const compareExpressions = (expr1, expr2) => {
+  const printDiff = () => {
     console.log('First expression:');
     printExprTree(expr1, '');
     console.log('Second expression:');
     printExprTree(expr2, '');
-  }
+  };
 
   if (expr1.type !== expr2.type) {
     printDiff();
     throw new Error(`Type differs: ${expr1.type} vs ${expr2.type}`);
   }
 
-  switch (expr1.type) {
-    case ExprType.CONST:
-      if (expr1.valueType !== expr2.valueType) {
-        printDiff();
-        throw new Error(
-          `Value type differs: ${expr1.valueType} vs ${expr2.vakueType}`
-        );
-      }
-      if (expr1.value !== expr2.value) {
-        printDiff();
-        throw new Error(`Value differs: ${expr1.value} vs ${expr2.value}`);
-      }
+  if (expr1.type === ExprType.CONST) {
+    if (expr1.valueType !== expr2.valueType) {
+      printDiff();
+      throw new Error(
+        `Value type differs: ${expr1.valueType} vs ${expr2.vakueType}`
+      );
+    }
+    if (expr1.value !== expr2.value) {
+      printDiff();
+      throw new Error(`Value differs: ${expr1.value} vs ${expr2.value}`);
+    }
   }
 
   if (expr1.children || expr2.children) {
@@ -80,7 +79,7 @@ function compareExpressions(expr1, expr2) {
     }
     const children = expr1.children.map((child1, i) => [
       child1,
-      expr2.children[i]
+      expr2.children[i],
     ]);
     const result = children.every(pair => compareExpressions(pair[0], pair[1]));
 
@@ -92,7 +91,7 @@ function compareExpressions(expr1, expr2) {
   }
 
   return true;
-}
+};
 
 describe('Parse Expressions', () => {
   it('should parse single operand expression', () => {
@@ -116,7 +115,7 @@ describe('Parse Expressions', () => {
     const tokens = [
       new Token(INT, 4),
       new Token(TokenType.MUL),
-      new Token(INT, 6)
+      new Token(INT, 6),
     ];
     const expr = parseExpression(tokens);
     const expected = new MultiplyExpr(
@@ -133,7 +132,7 @@ describe('Parse Expressions', () => {
       new Token(TokenType.PLUS),
       new Token(INT, 2),
       new Token(TokenType.MUL),
-      new Token(INT, 3)
+      new Token(INT, 3),
     ];
     const expr = parseExpression(tokens);
     const expected = new AddExpr(
@@ -153,7 +152,7 @@ describe('Parse Expressions', () => {
       new Token(TokenType.MUL),
       new Token(INT, 2),
       new Token(TokenType.PLUS),
-      new Token(INT, 3)
+      new Token(INT, 3),
     ];
     const expr = parseExpression(tokens);
     const expected = new AddExpr(
@@ -171,11 +170,11 @@ describe('Parse Expressions', () => {
       new Token(IDENTIFIER, 'hello'),
       new Token(LPAR),
       new Token(STRING, 'world'),
-      new Token(RPAR)
+      new Token(RPAR),
     ];
     const expr = parseExpression(tokens);
     const expected = new CallExpr(new IdentifierExpr('hello'), [
-      new ConstExpr(ValueType.STRING, 'world')
+      new ConstExpr(ValueType.STRING, 'world'),
     ]);
     expect(compareExpressions(expr, expected)).to.be.true;
   });
@@ -184,7 +183,7 @@ describe('Parse Expressions', () => {
     const tokens = [
       new Token(IDENTIFIER, 'hello'),
       new Token(LPAR),
-      new Token(RPAR)
+      new Token(RPAR),
     ];
     const expr = parseExpression(tokens);
     const expected = new CallExpr(new IdentifierExpr('hello'), []);
@@ -200,13 +199,13 @@ describe('Parse Expressions', () => {
       new Token(INT, 2),
       new Token(COMMA),
       new Token(INT, 3),
-      new Token(RPAR)
+      new Token(RPAR),
     ];
     const expr = parseExpression(tokens);
     const expected = new CallExpr(new IdentifierExpr('MAX'), [
       new ConstExpr(ValueType.INT, 1),
       new ConstExpr(ValueType.INT, 2),
-      new ConstExpr(ValueType.INT, 3)
+      new ConstExpr(ValueType.INT, 3),
     ]);
     expect(compareExpressions(expr, expected)).to.be.true;
   });
@@ -219,18 +218,18 @@ describe('Parse Expressions', () => {
       new Token(LPAR),
       new Token(IDENTIFIER, 'C'),
       new Token(RPAR),
-      new Token(RPAR)
+      new Token(RPAR),
     ];
     const expr = parseExpression(tokens);
     const expected = new CallExpr(new IdentifierExpr('A'), [
-      new CallExpr(new IdentifierExpr('B'), [new IdentifierExpr('C')])
+      new CallExpr(new IdentifierExpr('B'), [new IdentifierExpr('C')]),
     ]);
     expect(compareExpressions(expr, expected)).to.be.true;
   });
 
   it('should handle "NOT" operator', () => {
     const tokens = [new Token(NOT), new Token(INT, 0)];
-    const expr = parseExpression(tokens);
+    parseExpression(tokens);
   });
 
   it('should handle unary minus operator', () => {

--- a/src/parser/index.test.js
+++ b/src/parser/index.test.js
@@ -1,21 +1,11 @@
-const chai = require('chai');
-const expect = chai.expect;
+import { expect } from 'chai';
 
-import { parseStatement } from './';
+import { parseStatement } from '.';
 import { StatementType } from '../statement';
-import { tokenize, TokenType } from '../lex';
+import { tokenize } from '../lex';
 
 const T = text => tokenize(text);
 const P = text => parseStatement(T(text));
-
-const tokenToString = tok => {
-  switch (tok.type) {
-    case TokenType.INT:
-      return tok.value.toString();
-    default:
-      return tok.type;
-  }
-};
 
 describe('Parse Statements', () => {
   describe('DIM', () => {
@@ -23,7 +13,7 @@ describe('Parse Statements', () => {
       const s = P('DIM A(5)');
       expect(s.type).to.equal(StatementType.DIM);
       expect(s.arrays).to.deep.equal({
-        A: [5]
+        A: [5],
       });
     });
 
@@ -31,7 +21,7 @@ describe('Parse Statements', () => {
       const s = P('DIM A(5, 10, 15)');
       expect(s.type).to.equal(StatementType.DIM);
       expect(s.arrays).to.deep.equal({
-        A: [5, 10, 15]
+        A: [5, 10, 15],
       });
     });
 
@@ -40,7 +30,7 @@ describe('Parse Statements', () => {
       expect(s.type).to.equal(StatementType.DIM);
       expect(s.arrays).to.deep.equal({
         A: [11, 22],
-        B: [33, 44]
+        B: [33, 44],
       });
     });
   });
@@ -93,8 +83,8 @@ describe('Parse Statements', () => {
       expect(res).to.deep.equal([true, false, true]);
     });
 
-    it('with channel', () => {
-      const s = P('PRINT #5, 123');
+    it.skip('with channel', () => {
+      // const s = P('PRINT #5, 123');
       // expect(s.channel).to.deep.equal([{ type: TokenType.INT, value: 5 }]);
     });
   });

--- a/src/parser/parseCloseStatement.js
+++ b/src/parser/parseCloseStatement.js
@@ -5,10 +5,9 @@ import { CloseStatement } from '../statements/CloseStatement';
 
 export const parseCloseStatement = tokens => {
   popKeyword(tokens, Keyword.CLOSE);
-  let channel;
 
   popOptionalType(tokens, TokenType.HASH);
-  channel = parseExpression(tokens);
+  const channel = parseExpression(tokens);
 
   return new CloseStatement(channel);
 };

--- a/src/parser/parseDataStatement.js
+++ b/src/parser/parseDataStatement.js
@@ -1,18 +1,16 @@
-import { popKeyword, popOptionalType } from './utils';
-import { Keyword, TokenType } from '../lex';
+import { popKeyword, popOptionalType, valueFromToken } from './utils';
+import { Keyword, TokenType, Token } from '../lex';
 import { DataStatement } from '../statements/DataStatement';
-import { valueFromToken } from './utils';
-import { Value } from '../expr';
-import { Token } from '../lex';
 
 /**
  * @param {Token[]} tokens
+ * @returns {DataStatement}
  */
 export const parseDataStatement = tokens => {
   popKeyword(tokens, Keyword.DATA);
   const list = [];
 
-  while (true) {
+  for (;;) {
     // Should pop literals from tokens...
     const tok = popOptionalType(tokens, [
       TokenType.INT,

--- a/src/parser/parseDefStatement.js
+++ b/src/parser/parseDefStatement.js
@@ -3,7 +3,7 @@ import {
   popIdentifier,
   popOptionalType,
   popType,
-  popOptionalDataType
+  popOptionalDataType,
 } from './utils';
 import { Keyword, TokenType } from '../lex';
 import { DefStatement } from '../statements/DefStatement';
@@ -11,11 +11,11 @@ import { DefStatement } from '../statements/DefStatement';
 export const parseDefStatement = tokens => {
   popKeyword(tokens, Keyword.DEF);
   const dataType = popOptionalDataType(tokens);
-  const name = popIdentifier(tokens);
+  const functionName = popIdentifier(tokens);
   const args = [];
 
   if (popOptionalType(tokens, TokenType.LPAR)) {
-    while (true) {
+    for (;;) {
       const type = popOptionalDataType(tokens);
       const name = popIdentifier(tokens);
       args.push({ type, name });
@@ -26,5 +26,5 @@ export const parseDefStatement = tokens => {
     }
   }
 
-  return new DefStatement(dataType, name, args);
+  return new DefStatement(dataType, functionName, args);
 };

--- a/src/parser/parseIfStatement.js
+++ b/src/parser/parseIfStatement.js
@@ -1,9 +1,11 @@
 import { isKeyword, popKeyword, popOptionalType } from './utils';
 import { Keyword, TokenType } from '../lex';
 import { parseExpression } from './expression';
-import { parseStatement } from './index';
 import { IfStatement } from '../statements/ifStatement';
 import { GotoStatement } from '../statement';
+
+// eslint-disable-next-line import/no-cycle
+import { parseStatement } from './index';
 
 export const parseIfStatement = tokens => {
   popKeyword(tokens, Keyword.IF);

--- a/src/parser/parseInputStatement.js
+++ b/src/parser/parseInputStatement.js
@@ -16,7 +16,7 @@ export const parseInputStatement = tokens => {
   popKeyword(tokens, Keyword.INPUT);
   let channel;
   let tok;
-  let list = [];
+  const list = [];
 
   const isLineInput = !!popOptionalKeyword(tokens, Keyword.LINE);
 

--- a/src/parser/parseList.js
+++ b/src/parser/parseList.js
@@ -1,12 +1,13 @@
 import { popKeyword } from './utils';
 import { Keyword, TokenType } from '../lex';
 import { ListStatement } from '../statement';
+import { SyntaxError } from '../error';
 
 export const parseList = tokens => {
   // VAX BASIC Ref: page 109
   // Format: LIST, LIST n, LIST n-m, LIST n,n-m,...
   popKeyword(tokens, Keyword.LIST);
-  let ranges = [];
+  const ranges = [];
 
   if (tokens.length) {
     let from = null;
@@ -21,7 +22,7 @@ export const parseList = tokens => {
         ranges.push([from, to]);
       } else {
         if (from === null) {
-          new SyntaxError('Missing line number');
+          throw new SyntaxError('Missing line number');
         }
         ranges.push([from, from]);
       }

--- a/src/parser/parseOnStatement.js
+++ b/src/parser/parseOnStatement.js
@@ -21,7 +21,7 @@ export const parseOnStatement = tokens => {
   const targets = [];
   let otherwise;
 
-  while (true) {
+  for (;;) {
     const target = popType(tokens, TokenType.INT);
     targets.push(target.value);
     if (tokens.length && tokens[0].type === TokenType.COMMA) {
@@ -37,7 +37,7 @@ export const parseOnStatement = tokens => {
 
   if (action.value === Keyword.GOTO) {
     return new OnGotoStatement(expr, targets, otherwise);
-  } else {
-    return new OnGosubStatement(expr, targets, otherwise);
   }
+
+  return new OnGosubStatement(expr, targets, otherwise);
 };

--- a/src/parser/parsePrint.js
+++ b/src/parser/parsePrint.js
@@ -1,4 +1,4 @@
-import { popKeyword, popType, popOptionalType } from './utils';
+import { popKeyword, popOptionalType } from './utils';
 import { parseOptionalExpression, parseExpression } from './expression';
 import { Keyword, TokenType } from '../lex';
 import { PrintStatement } from '../statement';
@@ -8,7 +8,7 @@ export const parsePrint = tokens => {
   // Format: PRINT, PRINT expr, PRINT #channel, expr
   popKeyword(tokens, Keyword.PRINT);
   let channel = null;
-  let list = [];
+  const list = [];
 
   if (popOptionalType(tokens, TokenType.HASH)) {
     channel = parseExpression(tokens);

--- a/src/parser/parseReadStatement.js
+++ b/src/parser/parseReadStatement.js
@@ -5,12 +5,13 @@ import { ReadStatement } from '../statements/ReadStatement';
 
 /**
  * @param {Token[]} tokens
+ * @returns {ReadStatement}
  */
 export const parseReadStatement = tokens => {
   popKeyword(tokens, Keyword.READ);
   const list = [];
 
-  while (true) {
+  for (;;) {
     list.push(parseVar(tokens));
     if (!popOptionalType(tokens, TokenType.COMMA)) {
       break;

--- a/src/parser/utils.js
+++ b/src/parser/utils.js
@@ -1,5 +1,5 @@
 import { Token, TokenType } from '../lex';
-import { Value, ValueType } from '../expr';
+import { Value, ValueType } from '../Value';
 
 export const expectLineLength = (tokens, length) => {
   if (tokens.length > length) {

--- a/src/program.js
+++ b/src/program.js
@@ -1,9 +1,3 @@
-import { DefStatement } from './statements/DefStatement';
-import { Line } from './line';
-import { Value, ValueType } from './expr';
-import { UserFunction } from './UserFunction';
-import { DataStatement } from './statements/DataStatement';
-
 export class Program {
   constructor(lines) {
     // Array of lines in sorted order
@@ -12,7 +6,9 @@ export class Program {
     // Map of line number to line index
     this.lineToIndexMap = undefined;
 
-    lines && lines.map(line => this.add(line));
+    if (lines) {
+      lines.map(line => this.add(line));
+    }
   }
 
   add(line) {
@@ -43,26 +39,7 @@ export class Program {
   getUserFunctions() {
     const functions = [];
 
-    for (const line of this.lines) {
-      for (const stmt of line.statements) {
-        if (stmt instanceof DefStatement) {
-          functions[stmt.name] = new UserFunction(line.num);
-        }
-      }
-    }
-
     return functions;
-  }
-
-  getLineMap() {
-    // FIXME: not tested yet
-    if (!this.lineToIndexMap) {
-      this.lineToIndexMap = this.lines.reduce((m, line, i) => {
-        m[line.num] = i;
-        return m;
-      }, {});
-    }
-    return this.lineMap;
   }
 
   getRange(from, to) {
@@ -79,6 +56,8 @@ export class Program {
         return i;
       }
     }
+
+    return undefined;
   }
 
   lineIndexToNumber(idx) {
@@ -88,44 +67,5 @@ export class Program {
   getLineByNumber(num) {
     const idx = this.lineNumberToIndex(num);
     return this.lines[idx];
-  }
-
-  /**
-   * @param {Context} context
-   */
-  prepare(context) {
-    const userFunctions = this.getUserFunctions();
-    for (const name of Object.keys(userFunctions)) {
-      context.assignUserFunction(name, userFunctions[name]);
-    }
-
-    // Build data blocks
-    const data = [];
-    for (const line of this.lines) {
-      for (const stmt of line.statements) {
-        if (stmt instanceof DataStatement) {
-          data.push(...stmt.list);
-        }
-      }
-    }
-
-    context.data = data;
-    context.dataIndex = 0;
-  }
-
-  /**
-   * @param {string} source
-   * @param {Context} context
-   */
-  loadFromString(source, context) {
-    const lines = source.split('\n');
-
-    for (const line of lines) {
-      if (line.trim().length > 0) {
-        this.add(Line.parse(line));
-      }
-    }
-
-    this.prepare(context);
   }
 }

--- a/src/shell.js
+++ b/src/shell.js
@@ -1,14 +1,20 @@
-import { Line } from './line';
 import { RuntimeError } from './error';
+import { Program } from './program';
+import { Context } from './context';
+import { parseLine } from './parser';
 
 const PROMPT = '] ';
 
 export const input = async stream => {
-  return new Promise((resolve, reject) => {
+  return new Promise(resolve => {
     stream.once('data', data => resolve(data));
   });
 };
 
+/**
+ * @param {Program} program
+ * @param {Context} context
+ */
 export async function shell(program, context) {
   const printError = err => {
     let msg;
@@ -36,16 +42,18 @@ export async function shell(program, context) {
     }
   };
 
-  while (true) {
+  for (;;) {
     context.outputStream.write(PROMPT);
     const text = await input(context.inputStream);
 
     let line;
 
     try {
-      line = Line.parse(text.trim());
+      line = parseLine(text.trim());
     } catch (e) {
       printError(e);
+
+      // eslint-disable-next-line no-continue
       continue;
     }
 
@@ -53,27 +61,25 @@ export async function shell(program, context) {
       if (line.num !== undefined) {
         console.error(`FIXME: should delete line ${line.lineNo}`);
       }
-    } else {
-      if (line.num === undefined) {
-        try {
-          await line.exec(program, context);
-        } catch (e) {
-          if (e instanceof RuntimeError) {
-            e.setContext(context, program);
-            printError(e);
-            return;
-          } else {
-            printError(`There was an unhandled error:`);
-            printError(e);
-            printError(JSON.stringify(e.stack, null, 2));
-            console.log(e.stack);
-            console.trace();
-            printError(`Context: line index ${context.pc}`);
-          }
+    } else if (line.num === undefined) {
+      try {
+        await line.exec(program, context);
+      } catch (e) {
+        if (e instanceof RuntimeError) {
+          e.setContext(context, program);
+          printError(e);
+          return;
         }
-      } else {
-        program.add(line);
+
+        printError(`There was an unhandled error:`);
+        printError(e);
+        printError(JSON.stringify(e.stack, null, 2));
+        console.log(e.stack);
+        console.trace();
+        printError(`Context: line index ${context.pc}`);
       }
+    } else {
+      program.add(line);
     }
   }
 }

--- a/src/shell.js
+++ b/src/shell.js
@@ -2,14 +2,9 @@ import { RuntimeError } from './error';
 import { Program } from './program';
 import { Context } from './context';
 import { parseLine } from './parser';
+import io from './io';
 
 const PROMPT = '] ';
-
-export const input = async stream => {
-  return new Promise(resolve => {
-    stream.once('data', data => resolve(data));
-  });
-};
 
 /**
  * @param {Program} program
@@ -44,7 +39,7 @@ export async function shell(program, context) {
 
   for (;;) {
     context.outputStream.write(PROMPT);
-    const text = await input(context.inputStream);
+    const text = await io.input(context.inputStream);
 
     let line;
 

--- a/src/statement.js
+++ b/src/statement.js
@@ -26,7 +26,7 @@ export const StatementType = {
   DEBUG: 'debug',
   LET: 'let',
   NEXT: 'next',
-  RESUME: 'resume'
+  RESUME: 'resume',
 };
 
 export class BaseStatement {
@@ -55,7 +55,7 @@ export class GotoStatement extends BaseStatement {
     this.destination = destination;
   }
 
-  exec(program, context) {
+  exec() {
     return this.destination;
   }
 }
@@ -71,7 +71,9 @@ export class RemarkStatement extends BaseStatement {
     super(StatementType.REMARK);
   }
 
-  exec(program, context) {}
+  exec() {
+    // Does nothing at runtime
+  }
 }
 
 export class ListStatement extends BaseStatement {

--- a/src/statements/ChangeStatement.js
+++ b/src/statements/ChangeStatement.js
@@ -1,11 +1,13 @@
 import { BaseStatement, StatementType } from '../statement';
-import { Value, ValueType, ExprType } from '../expr';
+import { ExprType, Expr } from '../expr';
+import { Value, ValueType } from '../Value';
 import { RuntimeError } from '../error';
 
 export class ChangeStatement extends BaseStatement {
   /**
    * The from-expression must be either a variable name,
    * pointing to an array or a string, or a string value.
+   *
    * @param {Expr} fromExpr
    * @param {*} toName
    */
@@ -55,7 +57,7 @@ export class ChangeStatement extends BaseStatement {
 
       for (let i = 0; i < count; i++) {
         const n = fromArray.get([i + 1]);
-        str = str + String.fromCharCode(n.value);
+        str += String.fromCharCode(n.value);
       }
 
       context.assignVariable(this.toName, new Value(ValueType.STRING, str));

--- a/src/statements/CloseStatement.js
+++ b/src/statements/CloseStatement.js
@@ -6,7 +6,7 @@ export class CloseStatement extends BaseStatement {
     this.channel = channel;
   }
 
-  exec(program, context) {
+  exec() {
     throw new Error('CLOSE is not implemented');
   }
 }

--- a/src/statements/DataStatement.js
+++ b/src/statements/DataStatement.js
@@ -1,5 +1,5 @@
 import { BaseStatement, StatementType } from '../statement';
-import { Value } from '../expr';
+import { Value } from '../Value';
 
 export class DataStatement extends BaseStatement {
   /**
@@ -12,7 +12,7 @@ export class DataStatement extends BaseStatement {
     this.list = list;
   }
 
-  exec(program, context) {
+  exec() {
     // Does nothing at runtime
   }
 }

--- a/src/statements/DefStatement.js
+++ b/src/statements/DefStatement.js
@@ -34,7 +34,7 @@ export class DefStatement extends BaseStatement {
     this.args = args;
   }
 
-  exec(program, context) {
+  exec() {
     throw new Error('DEF statement should never be reached');
   }
 }

--- a/src/statements/DimStatement.js
+++ b/src/statements/DimStatement.js
@@ -1,6 +1,6 @@
 import { BaseStatement, StatementType } from '../statement';
 import BasicArray from '../BasicArray';
-import { ValueType } from '../expr';
+import { ValueType } from '../Value';
 import { Context } from '../context';
 import { Program } from '../program';
 

--- a/src/statements/EndStatement.js
+++ b/src/statements/EndStatement.js
@@ -8,7 +8,7 @@ export class EndStatement extends BaseStatement {
     this.blockType = blockType;
   }
 
-  exec(program, context) {
+  exec() {
     switch (this.blockType) {
       case null:
       case Keyword.PROGRAM:

--- a/src/statements/LetStatement.test.js
+++ b/src/statements/LetStatement.test.js
@@ -1,11 +1,10 @@
+import { expect } from 'chai';
 import Var from '../Var';
 import { Context } from '../context';
-import { ConstExpr, ValueType, Value } from '../expr';
+import { ConstExpr } from '../expr';
+import { ValueType } from '../Value';
 import { LetStatement } from './LetStatement';
 import BasicArray from '../BasicArray';
-
-const chai = require('chai');
-const expect = chai.expect;
 
 describe('LetStatement', () => {
   it('assigns value to variable', async () => {

--- a/src/statements/MarginStatement.js
+++ b/src/statements/MarginStatement.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import { BaseStatement, StatementType } from '../statement';
 import { Expr } from '../expr';
 import { Context } from '../context';
@@ -21,9 +19,12 @@ export class MarginStatement extends BaseStatement {
    * @param {Context} context
    */
   async exec(program, context) {
+    // eslint-disable-next-line no-unused-vars
     const channel =
       this.channel && (await this.channel.evaluate(program, context));
     const margin = await this.expr.evaluate(program, context);
+
+    // eslint-disable-next-line no-param-reassign
     context.options.margin = margin;
   }
 }

--- a/src/statements/OnGotoStatement.js
+++ b/src/statements/OnGotoStatement.js
@@ -7,7 +7,7 @@ export class OnGotoStatement extends BaseOnStatement {
   }
 
   async exec(program, context) {
-    const result = await this.expr.evaluate(program, context);
+    await this.expr.evaluate(program, context);
     console.warn('OnGotoStatement.exec is only a stub');
   }
 }

--- a/src/statements/OpenStatement.js
+++ b/src/statements/OpenStatement.js
@@ -2,7 +2,7 @@ import { BaseStatement, StatementType } from '../statement';
 
 export const OpenMode = {
   INPUT: 'INPUT',
-  OUTPUT: 'OUTPUT'
+  OUTPUT: 'OUTPUT',
 };
 
 export class OpenStatement extends BaseStatement {
@@ -12,7 +12,7 @@ export class OpenStatement extends BaseStatement {
     this.channel = channel;
   }
 
-  exec(program, context) {
+  exec() {
     throw new Error('OPEN is not implemented');
   }
 }

--- a/src/statements/QuoteStatement.js
+++ b/src/statements/QuoteStatement.js
@@ -13,7 +13,7 @@ export class QuoteStatement extends BaseStatement {
     this.channel = channel;
   }
 
-  exec(program, context) {
+  exec() {
     throw new Error('QUOTE is not implemented');
   }
 }

--- a/src/statements/ResumeStatement.js
+++ b/src/statements/ResumeStatement.js
@@ -6,7 +6,7 @@ export class ResumeStatement extends BaseStatement {
     this.target = target;
   }
 
-  exec(program, context) {
+  exec() {
     throw new Error('RESUME is not implemented');
   }
 }

--- a/src/statements/StopStatement.js
+++ b/src/statements/StopStatement.js
@@ -5,7 +5,7 @@ export class StopStatement extends BaseStatement {
     super(StatementType.STOP);
   }
 
-  exec(program, context) {
+  exec() {
     throw new Error('STOP is not implemented');
   }
 }

--- a/src/statements/WriteStatement.js
+++ b/src/statements/WriteStatement.js
@@ -7,7 +7,7 @@ export class WriteStatement extends BaseStatement {
     this.data = data;
   }
 
-  exec(program, context) {
+  exec() {
     throw new Error('WRITE is not implemented');
   }
 }

--- a/src/statements/forStatement.js
+++ b/src/statements/forStatement.js
@@ -1,16 +1,6 @@
 import { BaseStatement, StatementType } from '../statement';
-import { Value, ValueType } from '../expr';
+import { Value, ValueType } from '../Value';
 import { evaluateStatement } from '../evaluate';
-
-class ForStackEntry {
-  constructor(varName, from, to, step, line) {
-    this.varName = varName;
-    this.from = from;
-    this.to = to;
-    this.step = step;
-    this.line = line;
-  }
-}
 
 export class ForStatement extends BaseStatement {
   constructor(name, startExpr, finalExpr, stepExpr, untilExpr, whileExpr) {
@@ -62,5 +52,7 @@ export class ForStatement extends BaseStatement {
         entry: program.lineIndexToNumber(context.pc + 1),
       });
     }
+
+    return undefined;
   }
 }

--- a/src/statements/ifStatement.js
+++ b/src/statements/ifStatement.js
@@ -13,11 +13,13 @@ export class IfStatement extends BaseStatement {
     const result = await this.conditionExpr.evaluate(program, context);
     const block = result.isTrue() ? this.thenStatements : this.elseStatements;
 
-    for (let stmt of block || []) {
+    for (const stmt of block || []) {
       const jumpTo = await evaluateStatement(stmt, program, context);
       if (jumpTo !== undefined) {
         return jumpTo;
       }
     }
+
+    return undefined;
   }
 }

--- a/src/statements/inputStatement.js
+++ b/src/statements/inputStatement.js
@@ -1,5 +1,5 @@
 import { BaseStatement, StatementType } from '../statement';
-import { input as inputStreamInput } from '../shell';
+import io from '../io';
 import { assignIdentifierValue } from './utils';
 import { Value, ValueType } from '../Value';
 
@@ -20,7 +20,7 @@ export class InputStatement extends BaseStatement {
 
       context.outputStream.write(prompt);
 
-      const inp = await inputStreamInput(context.inputStream);
+      const inp = await io.input(context.inputStream);
 
       await assignIdentifierValue(
         program,

--- a/src/statements/inputStatement.js
+++ b/src/statements/inputStatement.js
@@ -1,7 +1,7 @@
 import { BaseStatement, StatementType } from '../statement';
 import { input as inputStreamInput } from '../shell';
 import { assignIdentifierValue } from './utils';
-import { Value, ValueType } from '../expr';
+import { Value, ValueType } from '../Value';
 
 export class InputStatement extends BaseStatement {
   constructor(channel, list) {

--- a/src/statements/nextStatement.js
+++ b/src/statements/nextStatement.js
@@ -1,5 +1,6 @@
 import { BaseStatement, StatementType } from '../statement';
-import { Value, ValueType } from '../expr';
+import { Value, ValueType } from '../Value';
+import { NextWithoutForError } from '../error';
 
 export class NextStatement extends BaseStatement {
   constructor(name) {
@@ -8,22 +9,23 @@ export class NextStatement extends BaseStatement {
   }
 
   exec(program, context) {
-    while (true) {
+    for (;;) {
       const info = context.popForLoop();
 
       if (!info) {
-        break;
+        throw new NextWithoutForError(context, program);
       }
 
-      if (info.name === this.name) {
+      if (info && info.name === this.name) {
         const val = context.get(this.name);
         let ival = val.value;
-        ival = ival + info.step;
+        ival += info.step;
         context.assignVariable(this.name, new Value(ValueType.INT, ival));
         if (ival <= info.final) {
           context.pushForLoop(info);
           return info.entry;
         }
+        break;
       }
     }
   }

--- a/src/statements/utils.js
+++ b/src/statements/utils.js
@@ -1,8 +1,12 @@
 import { RuntimeError } from '../error';
-import { Value, ValueType } from '../expr';
+import { Value, ValueType } from '../Value';
 import Var from '../Var';
+import { Program } from '../program';
+import { Context } from '../context';
 
 /**
+ * @param {Program} program
+ * @param {Context} context
  * @param {Var} identifier
  * @param {Value} value
  */

--- a/src/stream.js
+++ b/src/stream.js
@@ -12,7 +12,7 @@ export class Stream extends EventEmitter {
     // true - there are consumer of data, and the stream is not paused
     this.flowing = null;
 
-    this.on('newListener', topic => {
+    this.on('newListener', () => {
       if (this.flowing === null) {
         this.flowing = true;
       }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,18 +1,14 @@
-import { Program } from './program';
 import { Context } from './context';
 import { builtinFunctions } from './BasicFunction';
+import { parse } from './parser';
 
 export const setupEnvironment = source => {
-  const program = new Program();
   const context = new Context();
   const builtins = builtinFunctions();
+  const program = parse(source);
 
-  for (let name of Object.keys(builtins)) {
+  for (const name of Object.keys(builtins)) {
     context.assignFunction(name, builtins[name]);
-  }
-
-  if (source) {
-    program.loadFromString(source, context);
   }
 
   return { program, context };

--- a/tests/for_abuse.bas
+++ b/tests/for_abuse.bas
@@ -1,0 +1,2 @@
+10 NEXT i
+--- throws: "Next Without For Error" ---

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -1,17 +1,15 @@
 import fs from 'fs';
+import { expect } from 'chai';
 
 import { Stream } from '../src/stream';
 import { evaluateStatement } from '../src/evaluate';
 import { RunStatement } from '../src/statement';
 import { setupEnvironment } from '../src/utils';
 
-const chai = require('chai');
-const expect = chai.expect;
-
 const tests = fs.readdirSync(__dirname).filter(name => name.endsWith('.bas'));
 
 describe('Integration tests', () => {
-  for (let test of tests) {
+  for (const test of tests) {
     const content = fs.readFileSync(`${__dirname}/${test}`, 'utf-8');
     const lines = content.split('\n');
     const basLines = [];
@@ -23,11 +21,12 @@ describe('Integration tests', () => {
     let expectError;
     let receivedError;
 
-    for (let line of lines) {
+    for (const line of lines) {
       // Example: --- throws: "Out Of Memory" ---
       const throwMatch = line.match(/---+\s*throws:\s*"(.*)"/);
 
       if (throwMatch) {
+        // eslint-disable-next-line prefer-destructuring
         expectError = throwMatch[1];
       } else if (line.slice(0, 3) === '---') {
         dst = txtLines;
@@ -39,19 +38,18 @@ describe('Integration tests', () => {
     const src = basLines.join('\n');
     const txt = txtLines.join('\n').trim();
 
-    it(`${test}`, async function() {
+    it(`${test}`, async () => {
       if (skip) {
         this.skip();
         return;
       }
 
       const { program, context } = setupEnvironment(src);
-
       let output = '';
 
       context.outputStream = new Stream();
       context.outputStream.on('data', data => {
-        output = output + data;
+        output += data;
       });
 
       try {
@@ -65,6 +63,7 @@ describe('Integration tests', () => {
       }
 
       if (expectError) {
+        expect(receivedError).to.not.be.undefined;
         expect(expectError).to.equal(receivedError.message);
       }
 


### PR DESCRIPTION
This commit adds linting with eslint. It's a huge commit, but there is very few changes except for
fixing all linter errors.

A few substantials things have changed though, in order to fix those errors:

- `Value` and `ValueType` has finally moved to `Value.js` in order to fix import cycles
- Parsing have moved out from `Program` and `Line`, also to avoid import cycles
- Fixes bug where NEXT without matching FOR was not detected
- CircleCI now has a linter task